### PR TITLE
La palabra "delimeter" en este de pandas es errónea,cambio a "sep"

### DIFF
--- a/example1_Scikit-Learn.py
+++ b/example1_Scikit-Learn.py
@@ -6,7 +6,7 @@ import sklearn.linear_model
 
 # Load the data
 oecd_bli=pd.read_csv("oecd_bli_2015.csv",thousands=',')
-gdp_per_capita=pd.read_csv("gdp_per_capita.csv",thousands=',',delimeter='\t',encodin='latin1',na_values="n/a")
+gdp_per_capita=pd.read_csv("gdp_per_capita.csv",thousands=',',sep='\t',encoding='latin1',na_values="n/a")
 
 # Prepare the data
 # country_stats=prepare_country_stats(oecd_bli,gdp_per_capita)


### PR DESCRIPTION
Aquí vi que la palabra "sep" se utiliza como delimeter en el codigo de Aurélien

https://stackoverflow.com/questions/27896214/reading-tab-delimited-file-with-pandas-works-on-windows-but-not-on-mac